### PR TITLE
Changed refresh rate to 5 seconds

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -178,4 +178,4 @@ createAllMessages();
 inviteButton.addEventListener('click', () => inviteTab());
 
 // check for new messages after a certain amount of time. 
-setInterval(findNewMessages, 15000);
+setInterval(findNewMessages, 5000);


### PR DESCRIPTION
Set the refresh rate for the chat page to five seconds for the presentation. This means that new messages will populate every five seconds. 